### PR TITLE
Only show ansi colors if stdout is a tty

### DIFF
--- a/bin/cocos2d.py
+++ b/bin/cocos2d.py
@@ -34,7 +34,7 @@ class Logging:
 
     @staticmethod
     def _print(s, color=None):
-        if color:
+        if color and sys.stdout.isatty():
             print color + s + Logging.RESET
         else:
             print s


### PR DESCRIPTION
Only show ansi colors if stdout is a tty. This is to avoid seeing the ansi codes when the script output is redirected.
