### PR TITLE
dependencies output plus start application after installing (Android)

### DIFF
--- a/bin/cocos2d.py
+++ b/bin/cocos2d.py
@@ -246,11 +246,13 @@ def help():
 def run_plugin(command, plugins):
     plugin = plugins[command]()
     dependencies = plugin.depends_on()
+    dependencies_objects = {}
     if dependencies is not None:
         for dep_name in dependencies:
             #FIXME check there's not circular dependencies
-            run_plugin(dep_name, plugins)
-    plugin.run(argv)
+            dependencies_objects[dep_name] = run_plugin(dep_name, plugins)
+    plugin.run(argv, dependencies_objects)
+    return plugin
 
 
 

--- a/plugins/plugin_clean.py
+++ b/plugins/plugin_clean.py
@@ -63,7 +63,7 @@ class CCPluginClean(cocos2d.CCPlugin):
             return
         #TODO do it
 
-    def run(self, argv):
+    def run(self, argv, dependencies):
         self.parse_args(argv)
         self.clean_android()
         self.clean_ios()

--- a/plugins/plugin_compile.py
+++ b/plugins/plugin_compile.py
@@ -57,7 +57,7 @@ class CCPluginCompile(cocos2d.CCPlugin):
             return
         #TODO do it
 
-    def run(self, argv):
+    def run(self, argv, dependencies):
         self.parse_args(argv)
         self.build_android()
         self.build_ios()

--- a/plugins/plugin_install.py
+++ b/plugins/plugin_install.py
@@ -54,17 +54,22 @@ class CCPluginInstall(cocos2d.CCPlugin):
         if project_dir is None:
             return
 
-        package = self._xml_attr(project_dir, 'AndroidManifest.xml', 'manifest', 'package')
+        self.package = self._xml_attr(project_dir, 'AndroidManifest.xml', 'manifest', 'package')
+        activity_name = self._xml_attr(project_dir, 'AndroidManifest.xml', 'activity', 'android:name')
+        if activity_name.startswith('.'):
+            self.activity = self.package + activity_name
+        else:
+            self.activity = activity_name
+
         project_name = self._xml_attr(project_dir, 'build.xml', 'project', 'name')
         #TODO 'bin' is hardcoded, take the value from the Ant file
         apk_path = os.path.join(project_dir, 'bin', '%s-debug-unaligned.apk' % project_name)
 
         #TODO detect if the application is installed before running this
-        self._run_cmd("adb uninstall \"%s\"" % package)
+        self._run_cmd("adb uninstall \"%s\"" % self.package)
         self._run_cmd("adb install \"%s\"" % apk_path)
 
-    def run(self, argv):
+    def run(self, argv, dependencies):
         self.parse_args(argv)
         self.install_android()
-
 

--- a/plugins/plugin_jscompile/__init__.py
+++ b/plugins/plugin_jscompile/__init__.py
@@ -260,7 +260,7 @@ class CCPluginJSCompile(cocos2d.CCPlugin):
         self.handle_all_js_files()
         cocos2d.Logging.info("compilation finished")
 
-    def parse_args(self, argv):
+    def parse_args(self, argv, dependencies):
         """
         """
         from optparse import OptionParser

--- a/plugins/plugin_new.py
+++ b/plugins/plugin_new.py
@@ -79,7 +79,7 @@ class CCPluginNew(cocos2d.CCPlugin):
         # 3rd create default directories
 
     # main entry point
-    def run(self, argv):
+    def run(self, argv, dependencies):
         args = self.parse_args(argv)
         self.create_project(args)
 

--- a/plugins/plugin_run.py
+++ b/plugins/plugin_run.py
@@ -33,6 +33,9 @@ class CCPluginRun(cocos2d.CCPlugin):
     def brief_description():
         return "compiles a project and install the files on a device"
 
-    def run(self, argv):
-        # it does nothing on it's own
-        pass
+    def run(self, argv, dependencies):
+        cocos2d.Logging.info("starting application")
+        self.parse_args(argv)
+        install_dep = dependencies['install']
+        self._run_cmd("adb shell am start -n %s/%s" %
+            (install_dep.package, install_dep.activity))

--- a/plugins/plugin_update.py
+++ b/plugins/plugin_update.py
@@ -56,6 +56,6 @@ class CCPluginUpdate(cocos2d.CCPlugin):
             conn.close()
 
 
-    def run(self, argv):
+    def run(self, argv, dependencies):
     	self.parse_args(argv)
         self._check_versions()

--- a/plugins/plugin_version.py
+++ b/plugins/plugin_version.py
@@ -47,7 +47,7 @@ class CCPluginVersion(cocos2d.CCPlugin):
     		else:
     			raise cocos2d.CCPluginError("Couldn't find version info")
 
-    def run(self, argv):
+    def run(self, argv, dependencies):
     	self.parse_args(argv)
         self._show_versions()
 


### PR DESCRIPTION
This pull request has two things:
- Plugin's dependencies are stored and passed as argument to the plugin
- 'run' plugin starts the installed application on the device (Android)
