### PR TITLE
pass extra (user defined) parameters to closure compiler

### DIFF
--- a/plugins/plugin_jscompile/bin/compiler_config_sample.json
+++ b/plugins/plugin_jscompile/bin/compiler_config_sample.json
@@ -30,5 +30,6 @@
         "js/jsb_debugger.js",
         "js/jsb.js",
         "js/main.debug.js"
-    ]
+    ],
+    "closure_params": ""
 }


### PR DESCRIPTION
jscompile plugin now can pass extra parameters to Google Closure Compiler. These parameters can be specified in the .json config file or using -m. The ones supplied with -m have priority over the ones in the config file.
