### PR TITLE
Selecting active platform

### DIFF
--- a/plugins/plugin_clean.py
+++ b/plugins/plugin_clean.py
@@ -33,9 +33,10 @@ class CCPluginClean(cocos2d.CCPlugin):
         return "removes files produced by compilation"
 
     def clean_android(self):
-        project_dir = self._platforms.android_path
-        if project_dir is None:
+        if not self._platforms.is_android_active():
             return
+        project_dir = self._platforms.project_path()
+
         cocos2d.Logging.info("cleaning native")
         obj_path = os.path.join(project_dir, 'obj')
         if os.path.exists(obj_path):
@@ -47,9 +48,9 @@ class CCPluginClean(cocos2d.CCPlugin):
         self._run_cmd("cd \"%s\" && ant clean" % project_dir)
 
     def clean_ios(self):
-        project_dir = self._platforms.ios_path
-        if project_dir is None:
+        if not self._platforms.is_ios_active():
             return
+        project_dir = self._platforms.project_path()
         #TODO do it
 
     def run(self, argv, dependencies):

--- a/plugins/plugin_compile.py
+++ b/plugins/plugin_compile.py
@@ -33,9 +33,9 @@ class CCPluginCompile(cocos2d.CCPlugin):
         return "compiles a project in debug mode"
 
     def build_android(self):
-        project_dir = self._platforms.android_path
-        if project_dir is None:
+        if not self._platforms.is_android_active():
             return
+        project_dir = self._platforms.project_path()
 
         cocos2d.Logging.info("building native")
         self._run_cmd("cd \"%s\" && ./build_native.sh" % project_dir)
@@ -43,9 +43,9 @@ class CCPluginCompile(cocos2d.CCPlugin):
         self._run_cmd("cd \"%s\" && ant debug" % project_dir)
 
     def build_ios(self):
-        project_dir = self._platforms.ios_path
-        if project_dir is None:
+        if not self._platforms.is_ios_active():
             return
+        project_dir = self._platforms.project_path()
         #TODO do it
 
     def run(self, argv, dependencies):

--- a/plugins/plugin_install.py
+++ b/plugins/plugin_install.py
@@ -38,12 +38,11 @@ class CCPluginInstall(cocos2d.CCPlugin):
         return doc.getElementsByTagName(node_name)[0].getAttribute(attr)
 
     def install_android(self):
-        cocos2d.Logging.info("installing on device")
-
-        project_dir = self._platforms.android_path
-        if project_dir is None:
+        if not self._platforms.is_android_active():
             return
+        project_dir = self._platforms.project_path()
 
+        cocos2d.Logging.info("installing on device")
         self.package = self._xml_attr(project_dir, 'AndroidManifest.xml', 'manifest', 'package')
         activity_name = self._xml_attr(project_dir, 'AndroidManifest.xml', 'activity', 'android:name')
         if activity_name.startswith('.'):


### PR DESCRIPTION
Changed how the current platform for the project is handled:
- If the project can be built for only one platform, select that platform automatically
- If the project has several platforms, one can be supplied via command line (`-p ios|android`)
- If the project has several platforms, and none was supplied via command line, show a list of options and let the user choose one
