### PR TITLE
'dist' plugin and added iOS functionality for 'compile' and 'clean'

### DIFF
--- a/bin/cocos2d.ini
+++ b/bin/cocos2d.ini
@@ -12,4 +12,5 @@ plugin_install.CCPluginInstall
 plugin_update.CCPluginUpdate
 plugin_clean.CCPluginClean
 plugin_run.CCPluginRun
+plugin_dist.CCPluginDist
 # To add a new plugin add it's classname here

--- a/bin/cocos2d.py
+++ b/bin/cocos2d.py
@@ -78,6 +78,27 @@ class CCPlugin(object):
                 message += ". Check the log file at %s" % log_path
             raise CCPluginError(message)
 
+    def _output_for(self, command):
+        if self._verbose:
+            Logging.debug("running: '%s'\n" % command)
+        else:
+            log_path = CCPlugin._log_path()
+
+        try:
+            return subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError as e:
+            output = e.output
+            message = "Error running command"
+
+            if not self._verbose:
+                with open(log_path, 'w') as f:
+                    f.write(output)
+                message += ". Check the log file at %s" % log_path
+            else:
+                Logging.error(output)
+
+            raise CCPluginError(message)
+
     @staticmethod
     def _log_path():
         log_dir = os.path.expanduser("~/.cocos2d")

--- a/plugins/plugin_clean.py
+++ b/plugins/plugin_clean.py
@@ -12,12 +12,11 @@
 
 __docformat__ = 'restructuredtext'
 
-import sys
 import os
-import json
 import shutil
 
 import cocos2d
+from plugin_dist import CCPluginDist
 
 class CCPluginClean(cocos2d.CCPlugin):
     """
@@ -39,11 +38,7 @@ class CCPluginClean(cocos2d.CCPlugin):
 
         cocos2d.Logging.info("cleaning native")
         obj_path = os.path.join(project_dir, 'obj')
-        if os.path.exists(obj_path):
-            try:
-                shutil.rmtree(obj_path)
-            except OSError as e:
-                raise cocos2d.CCPluginError("Error cleaning native: " + str(e.args))
+        self._rmdir(obj_path)
         cocos2d.Logging.info("cleaning java")
         self._run_cmd("cd \"%s\" && ant clean" % project_dir)
 
@@ -51,7 +46,18 @@ class CCPluginClean(cocos2d.CCPlugin):
         if not self._platforms.is_ios_active():
             return
         project_dir = self._platforms.project_path()
-        #TODO do it
+
+        cocos2d.Logging.info("removing intermediate files")
+        self._run_cmd("cd \"%s\" && xcodebuild clean" % project_dir)
+        self._rmdir(CCPluginDist.target_path(project_dir))
+
+    def _rmdir(self, path):
+        if os.path.exists(path):
+            try:
+                shutil.rmtree(path)
+            except OSError as e:
+                raise cocos2d.CCPluginError("Error removing directory: " + str(e.args))
+
 
     def run(self, argv, dependencies):
         self.parse_args(argv)

--- a/plugins/plugin_compile.py
+++ b/plugins/plugin_compile.py
@@ -12,11 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-import sys
-import os
-import json
-import inspect
-
 import cocos2d
 
 class CCPluginCompile(cocos2d.CCPlugin):
@@ -46,7 +41,8 @@ class CCPluginCompile(cocos2d.CCPlugin):
         if not self._platforms.is_ios_active():
             return
         project_dir = self._platforms.project_path()
-        #TODO do it
+        cocos2d.Logging.info("building")
+        self._run_cmd("cd \"%s\" && xcodebuild build" % project_dir)
 
     def run(self, argv, dependencies):
         self.parse_args(argv)

--- a/plugins/plugin_dist.py
+++ b/plugins/plugin_dist.py
@@ -43,7 +43,7 @@ class CCPluginDist(cocos2d.CCPlugin):
                           dest="provisioning",
                           help="provisioning profile to use (needed for iOS distribution)")
         
-    def build_android(self):
+    def dist_android(self):
         if not self._platforms.is_android_active():
             return
         project_dir = self._platforms.project_path()
@@ -68,7 +68,7 @@ class CCPluginDist(cocos2d.CCPlugin):
     def target_path(project_dir):
         return os.path.join(project_dir, '..', 'target')
         
-    def build_ios(self):
+    def dist_ios(self):
         if not self._platforms.is_ios_active():
             return
         project_dir = self._platforms.project_path()
@@ -90,5 +90,5 @@ class CCPluginDist(cocos2d.CCPlugin):
 
     def run(self, argv, dependencies):
         self.parse_args(argv)
-        self.build_android()
-        self.build_ios()
+        self.dist_android()
+        self.dist_ios()

--- a/plugins/plugin_dist.py
+++ b/plugins/plugin_dist.py
@@ -86,7 +86,7 @@ class CCPluginDist(cocos2d.CCPlugin):
             os.remove(ipa_path)
         self._run_cmd("cd '%s' && xcodebuild -exportArchive -exportFormat IPA -archivePath '%s' -exportPath '%s' -exportProvisioningProfile '%s'" % (project_dir, archive_path, ipa_path, self._provisioning))
         cocos2d.Logging.info("\nThe ipa was created at:\n%s" % os.path.abspath(ipa_path))
-        cocos2d.Logging.info("\nNow you can used 'Application Loader' to submit the .ipa\n")
+        cocos2d.Logging.info("\nNow you can use 'Application Loader' to submit the .ipa\n")
 
     def run(self, argv, dependencies):
         self.parse_args(argv)

--- a/plugins/plugin_dist.py
+++ b/plugins/plugin_dist.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+# ----------------------------------------------------------------------------
+# cocos2d "dist" plugin
+#
+# Copyright 2014 (C) Luis Parravicini
+#
+# License: MIT
+# ----------------------------------------------------------------------------
+'''
+"dist" plugin for cocos2d command line tool
+'''
+
+__docformat__ = 'restructuredtext'
+
+import re
+import os
+import cocos2d
+
+class CCPluginDist(cocos2d.CCPlugin):
+    """
+    builds a project for distribution
+    """
+
+    @staticmethod
+    def plugin_name():
+      return "dist"
+
+    @staticmethod
+    def brief_description():
+        return "builds a project for distribution"
+
+    def init(self, options, working_dir):
+        super(CCPluginDist, self).init(options, working_dir)
+
+        if self._platforms.is_ios_active():
+            if not options.provisioning:
+                raise cocos2d.CCPluginError("Provisioning profile is needed")
+            else:
+                self._provisioning = options.provisioning
+
+    def _add_custom_options(self, parser):
+        parser.add_option("-f", "--provisioning",
+                          dest="provisioning",
+                          help="provisioning profile to use (needed for iOS distribution)")
+        
+    def build_android(self):
+        if not self._platforms.is_android_active():
+            return
+        project_dir = self._platforms.project_path()
+
+        raise cocos2d.CCPluginError("unimplemented")
+
+    def _find_ios_scheme(self, project_dir):
+        out = self._output_for("cd \"%s\" && xcodebuild -list" % project_dir)
+
+        match = re.search('Schemes:(.*)', out, re.DOTALL)
+        if match is None:
+            raise cocos2d.CCPluginError("Couldn't find the schemes list")
+
+        schemes = match.group(1).split()
+        if len(schemes) == 0:
+            raise cocos2d.CCPluginError("Couldn't find a scheme")
+        
+        return schemes[0]
+
+
+    @staticmethod
+    def target_path(project_dir):
+        return os.path.join(project_dir, '..', 'target')
+        
+    def build_ios(self):
+        if not self._platforms.is_ios_active():
+            return
+        project_dir = self._platforms.project_path()
+
+        scheme = self._find_ios_scheme(project_dir)
+        cocos2d.Logging.info("using scheme %s" % scheme)
+
+        archive_path = os.path.join(CCPluginDist.target_path(project_dir), scheme + '.xcarchive')
+        cocos2d.Logging.info("archiving")
+        self._run_cmd("cd '%s' && xcodebuild -scheme '%s' -archivePath '%s' archive" % (project_dir, scheme, archive_path))
+
+        cocos2d.Logging.info("exporting archive")
+        ipa_path = os.path.join(os.path.dirname(archive_path), scheme + '.ipa')
+        if os.path.exists(ipa_path):
+            os.remove(ipa_path)
+        self._run_cmd("cd '%s' && xcodebuild -exportArchive -exportFormat IPA -archivePath '%s' -exportPath '%s' -exportProvisioningProfile '%s'" % (project_dir, archive_path, ipa_path, self._provisioning))
+        cocos2d.Logging.info("\nThe ipa was created at:\n%s" % os.path.abspath(ipa_path))
+        cocos2d.Logging.info("\nNow you can used 'Application Loader' to submit the .ipa\n")
+
+    def run(self, argv, dependencies):
+        self.parse_args(argv)
+        self.build_android()
+        self.build_ios()


### PR DESCRIPTION
The `compile` plugin now builds the iOS project using xcodebuild.

I've added a `dist` plugin which (for now) supports only iOS. The plugin creates an archive for the project and then exports that as an .ipa. **Warning**: This is the first time I've built an iOS project using the command line. It may not be the best way to create it, I don't know. The test I've made was to use this plugin to create the .ipa for my game and submitting it to iTC, it's now in 'Waiting for review'.
