### PR TITLE
exit status

### DIFF
--- a/bin/cocos.py
+++ b/bin/cocos.py
@@ -438,5 +438,6 @@ if __name__ == "__main__":
         #with that name.
         if e.__class__.__name__ == 'CCPluginError':
             Logging.error(' '.join(e.args))
+            sys.exit(1)
         else:
             raise


### PR DESCRIPTION
When a plugin aborts its execution throwing a CCPluginError, the main script exits with status 1 for other scripts to be able to determine if there was an error.
