### PR TITLE
fix the bug of convering v0.1 copy resource cfg to v0.2

### DIFF
--- a/plugins/project_compile/project_compile.py
+++ b/plugins/project_compile/project_compile.py
@@ -250,6 +250,9 @@ class CCPluginCompile(cocos.CCPlugin):
             else:
                 to_dir = os.path.basename(element)
                 ret_element["from"] = element
+                # maybe is a normal file not a dir
+                if "." in to_dir:
+                    to_dir = ""
                 ret_element["to"] = to_dir
 
             ret.append(ret_element)


### PR DESCRIPTION
Consider the following cfg in v0.1 :

```
"copy_to_assets" :[
        "../../../main.js"
]
```

in v0.2 it will be converted to wrong cfg:

```
   "copy_resources": [
        {
            "from": "../../../main.js", 
            "to": "main.js"
        },
```

the right cfg should be:

```
   "copy_resources": [
        {
            "from": "../../../main.js", 
            "to": ""
        },
```
