### PR TITLE
Do not show passwords when entering or signing

### DIFF
--- a/plugins/project_compile/build_android.py
+++ b/plugins/project_compile/build_android.py
@@ -301,7 +301,7 @@ class AndroidBuilder(object):
             self.key_store = os.path.join(self.app_android_root, self.key_store)
 
         if self.key_store_pass is None:
-            self.key_store_pass = self._get_user_input("Please input the password of key store:")
+            self.key_store_pass = self._get_secure_user_input("Please input the password of key store:")
             self._write_build_cfg(AndroidBuilder.CFG_KEY_STORE_PASS, self.key_store_pass)
 
         if self.alias is None:
@@ -309,7 +309,7 @@ class AndroidBuilder(object):
             self._write_build_cfg(AndroidBuilder.CFG_KEY_ALIAS, self.alias)
 
         if self.alias_pass is None:
-            self.alias_pass = self._get_user_input("Please input the password of alias:")
+            self.alias_pass = self._get_secure_user_input("Please input the password of alias:")
             self._write_build_cfg(AndroidBuilder.CFG_KEY_ALIAS_PASS, self.alias_pass)
 
         # sign the apk
@@ -346,6 +346,11 @@ class AndroidBuilder(object):
             break
 
         return ret
+
+    def _get_secure_user_input(self, tip_msg):
+        import getpass
+        cocos.Logging.warning(tip_msg)
+        return getpass.getpass('')
 
     def _write_build_cfg(self, key, value):
         try:

--- a/plugins/project_compile/build_android.py
+++ b/plugins/project_compile/build_android.py
@@ -323,9 +323,9 @@ class AndroidBuilder(object):
         # output tips
         cocos.Logging.warning("\nThe release apk was signed, the signed apk path is %s" % signed_path)
         cocos.Logging.warning("\nkeystore file : %s" % self.key_store)
-        cocos.Logging.warning("password of keystore file : %s" % self.key_store_pass)
+        cocos.Logging.warning("password of keystore file : %s" % ("*" * len(self.key_store_pass)))
         cocos.Logging.warning("alias : %s" % self.alias)
-        cocos.Logging.warning("password of alias : %s\n" % self.alias_pass)
+        cocos.Logging.warning("password of alias : %s\n" % ("*" * len(self.alias_pass)))
         cocos.Logging.warning("The properties for sign was stored in file %s\n" % self.cfg_path)
 
     def _zipalign_apk(self, apk_file, aligned_file, sdk_root):


### PR DESCRIPTION
These changes prevent the password from being visible to someone watching over your shoulder.
