### PR TITLE
Added `@echo off`

### DIFF
--- a/bin/cocos.bat
+++ b/bin/cocos.bat
@@ -1,2 +1,3 @@
-python %~dp0/cocos.py %*
+@echo off
+@python %~dp0/cocos.py %*
 


### PR DESCRIPTION
Python command is being printed resulting in messy command line. `@echo off` will hide the printing of the python command.
