### PR TITLE
use another Android.mk file when release build

### DIFF
--- a/plugins/project_compile/build_android.py
+++ b/plugins/project_compile/build_android.py
@@ -191,6 +191,11 @@ class AndroidBuilder(object):
 
         if build_mode == 'debug':
             ndk_build_cmd = '%s NDK_DEBUG=1' % ndk_build_cmd
+        elif build_mode == 'release':
+            ndk_build_cmd = '%s NDK_DEBUG=0' % ndk_build_cmd
+            app_mk = '%s/jni/Application_release.mk' % app_android_root
+            if os.path.exists(app_mk):
+              ndk_build_cmd = '%s NDK_APPLICATION_MK=%s' % (ndk_build_cmd, app_mk)
 
         self._run_cmd(ndk_build_cmd)
 


### PR DESCRIPTION
To turn off 'COCOS2D_DEBUG' flug, use other .mk file when android release build. It applyed only if file exits.

see also
https://github.com/cocos2d/cocos2d-x/pull/6713
