### PR TITLE
Modify the logic of compiling for iOS & Mac.

### DIFF
--- a/bin/cocos.py
+++ b/bin/cocos.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 import cocos_project
 import shutil
 
-COCOS2D_CONSOLE_VERSION = '0.8'
+COCOS2D_CONSOLE_VERSION = '0.9'
 
 
 class Logging:

--- a/plugins/project_deploy.py
+++ b/plugins/project_deploy.py
@@ -64,7 +64,7 @@ class CCPluginDeploy(cocos.CCPlugin):
 
         compile_dep = dependencies['compile']
         self._iosapp_path = compile_dep._iosapp_path
-        self._mode = compile_dep._mode
+        self._use_sdk = compile_dep.use_sdk
 
     def deploy_mac(self, dependencies):
         if not self._platforms.is_mac_active():

--- a/plugins/project_run/project_run.py
+++ b/plugins/project_run/project_run.py
@@ -64,7 +64,7 @@ class CCPluginRun(cocos.CCPlugin):
             cocos.Logging.warning("The signed app & ipa are generated in path : %s" % os.path.dirname(deploy_dep._iosapp_path))
         else:
             iossim_exe_path = os.path.join(os.path.dirname(__file__), 'bin', 'ios-sim')
-            launch_sim = "%s launch %s &" % (iossim_exe_path, deploy_dep._iosapp_path)
+            launch_sim = "%s launch \"%s\" &" % (iossim_exe_path, deploy_dep._iosapp_path)
             self._run_cmd(launch_sim)
 
     def run_mac(self, dependencies):

--- a/plugins/project_run/project_run.py
+++ b/plugins/project_run/project_run.py
@@ -60,7 +60,8 @@ class CCPluginRun(cocos.CCPlugin):
             return
 
         deploy_dep = dependencies['deploy']
-        if deploy_dep._mode == 'release':
+        if deploy_dep._use_sdk == 'iphoneos':
+            cocos.Logging.warning("The generated app is for device. Can't run it on simulator.")
             cocos.Logging.warning("The signed app & ipa are generated in path : %s" % os.path.dirname(deploy_dep._iosapp_path))
         else:
             iossim_exe_path = os.path.join(os.path.dirname(__file__), 'bin', 'ios-sim')


### PR DESCRIPTION
1. Add argument "-t" in "cocos compile" to specify the target name for compiling iOS/Mac project.
2. Support sign the app with debug mode
3. When the sign id is specified, compile the project for device.
