### PR TITLE
Modify the logic of compiling scripts when building project.

### DIFF
--- a/bin/cocos.py
+++ b/bin/cocos.py
@@ -24,7 +24,7 @@ import shutil
 import string
 import ConfigParser
 
-COCOS2D_CONSOLE_VERSION = '1.3'
+COCOS2D_CONSOLE_VERSION = '1.4'
 
 
 class Cocos2dIniParser:

--- a/bin/cocos2d.ini
+++ b/bin/cocos2d.ini
@@ -32,13 +32,13 @@ plugin_luacompile.CCPluginLuaCompile
 # example: /usr/local/cocos2d-x
 # eg: this file must exist: /usr/local/cocos2d-x/cocos/cocos2d.h
 # Default: empty. Installers will populate it
-cocos2d_x=
+cocos2d_x=../../..
 
 # where are the cocos2d-x's templates installed
 # example: /home/user/templates
 # eg: this directory must exist: /home/user/templates/cpp-template-default
 # Default: empty. Installers will populate it
-templates=
+templates=../../../templates
 
 # where are the plugins installed
 # but distros can override this directory

--- a/plugins/project_compile/build_android.py
+++ b/plugins/project_compile/build_android.py
@@ -319,7 +319,11 @@ class AndroidBuilder(object):
 
         # check the project config & compile the script files
         assets_dir = os.path.join(app_android_root, "assets")
-        compile_obj.compile_scripts(assets_dir, assets_dir)
+        if self._project._is_lua_project():
+            compile_obj.compile_lua_scripts(assets_dir, assets_dir)
+
+        if self._project._is_js_project():
+            compile_obj.compile_js_scripts(assets_dir, assets_dir)
 
         # run ant build
         ant_path = os.path.join(ant_root, 'ant')


### PR DESCRIPTION
1. Developers can only encrypt the lua scripts without compiling them into byte-code.
2. Not compiling lua scripts into byte-code when building project for iOS.
