### PR TITLE
Solve a problem of signing android apk with new version of android sdk.

### DIFF
--- a/plugins/project_compile/build_android.py
+++ b/plugins/project_compile/build_android.py
@@ -409,7 +409,16 @@ For More information:
             shutil.copy(gen_apk_path, output_dir)
             cocos.Logging.info("Move apk to %s" % output_dir)
 
-            return os.path.join(output_dir, apk_name)
+            if build_mode == "release":
+                signed_name = "%s-%s-signed.apk" % (project_name, build_mode)
+                apk_path = os.path.join(output_dir, signed_name)
+                if os.path.exists(apk_path):
+                    os.remove(apk_path)
+                os.rename(os.path.join(output_dir, apk_name), apk_path)
+            else:
+                apk_path = os.path.join(output_dir, apk_name)
+
+            return apk_path
         else:
             raise cocos.CCPluginError("Not specified the output directory!")
 


### PR DESCRIPTION
The logic before this PR:
`cocos compile` will Sign & zipalign the apk if the sign related properties not specified in `ant.properties`.

The new logic is:
Gather the sign related properties and write them into `ant.properties`. Then invoke ant command to sign & zipalign the apk.
