### PR TITLE
Fix: Command 'NEW' -> 'access denied'

### DIFF
--- a/plugins/project_new/project_new.py
+++ b/plugins/project_new/project_new.py
@@ -266,8 +266,11 @@ class Templates(object):
         self._template_folders = {}
 
         for templates_dir in self._templates_paths:
-            dirs = [name for name in os.listdir(templates_dir) if os.path.isdir(
-                os.path.join(templates_dir, name))]
+            try:
+                dirs = [name for name in os.listdir(templates_dir) if os.path.isdir(
+                    os.path.join(templates_dir, name))]
+            except OSError, msg:
+                continue
             pattern = template_pattern[self._lang]
             for name in dirs:
                 match = re.search(pattern, name)


### PR DESCRIPTION
Fix the command 'NEW' when it tries to find 'templates' dir with 'access denied'
(catch exception and skip the dir)
