### PR TITLE
Optimize the logic of cocos2d-console.

### DIFF
--- a/plugins/project_compile/build_android.py
+++ b/plugins/project_compile/build_android.py
@@ -199,7 +199,7 @@ For More information:
         app_android_root = self.app_android_root
         reload(sys)
         sys.setdefaultencoding('utf8')
-        ndk_path = os.path.join(ndk_root, "ndk-build")
+        ndk_path = cocos.CMDRunner.convert_path_to_cmd(os.path.join(ndk_root, "ndk-build"))
 
         module_paths = []
         for cfg_path in self.ndk_module_paths:

--- a/plugins/project_run/project_run.py
+++ b/plugins/project_run/project_run.py
@@ -93,7 +93,7 @@ class CCPluginRun(cocos.CCPlugin):
         sdk_root = cocos.check_environment_variable('ANDROID_SDK_ROOT')
         adb_path = cocos.CMDRunner.convert_path_to_cmd(os.path.join(sdk_root, 'platform-tools', 'adb'))
         deploy_dep = dependencies['deploy']
-        startapp = "%s shell am start \"%s/%s\"" % (adb_path, deploy_dep.package, deploy_dep.activity)
+        startapp = "%s shell am start -n \"%s/%s\"" % (adb_path, deploy_dep.package, deploy_dep.activity)
         self._run_cmd(startapp)
         pass
 


### PR DESCRIPTION
1. Solve the error when starting android app on android 2.3.
2. Consider the spaces in the path of ndk-build.
