### PR TITLE
Select correct python version.

### DIFF
--- a/bin/cocos
+++ b/bin/cocos
@@ -3,5 +3,11 @@
 COCOS_CONSOLE_BIN_DIRECTORY=$(dirname "$0")
 COCOS_CONSOLE_BIN_DIRECTORY=$(cd "$COCOS_CONSOLE_BIN_DIRECTORY" && pwd -P)
 
-exec python "$COCOS_CONSOLE_BIN_DIRECTORY/cocos.py" "$@"
+# Find python version 2 interpreter
+PYTHON=python
+if which python2 > /dev/null 2>&1; then
+  PYTHON=python2
+fi
+
+exec $PYTHON "$COCOS_CONSOLE_BIN_DIRECTORY/cocos.py" "$@"
 


### PR DESCRIPTION
On some systems (Arch Linux, MSYS2 on Windows), executable file of version 2 of the Python has name `python2`. Executable named `python` on these systems belongs to version 3 of the Python interpreter.

But cocos console written only for Python version 2.

This patch change startup shell script to select correct version of python to start cocos console.

It would be very good to merge this pull request also to `v3` branch.
