### PR TITLE
Solve the error when compiling android project with release mode on Windows.

### DIFF
--- a/plugins/project_compile/build_android.py
+++ b/plugins/project_compile/build_android.py
@@ -582,7 +582,7 @@ class AndroidBuilder(object):
                 abs_path = inputed
 
             if os.path.isfile(abs_path):
-                user_cfg[self.key_store_str] = inputed
+                user_cfg[self.key_store_str] = inputed.replace('\\', '/')
                 break
             else:
                 cocos.Logging.warning(MultiLanguage.get_string('COMPILE_INFO_NOT_A_FILE'))


### PR DESCRIPTION
If the path of keystore file inputed contains `\`, `ant` will report error.
The solution is : Replace the `\` to `/` when store the path of keystore file.
