### PR TITLE
Enable source code debugging for cocos2dx static link library(ios, mac)

### DIFF
--- a/plugins/plugin_generate/configs/gen_libs_config.json
+++ b/plugins/plugin_generate/configs/gen_libs_config.json
@@ -46,5 +46,9 @@
         "cocos/editor-support/spine/Android.mk",
         "tools/simulator/libsimulator/proj.android/Android.mk"
     ],
-    "support_vs_versions" : [ 2015, 2013 ]
+    "support_vs_versions" : [ 2015, 2013 ],
+    "xcode_build_options" : {
+        "release": "",
+        "debug": "GENERATE_DEBUG_SYMBOLS=YES"
+    }
 }


### PR DESCRIPTION
- Added xcode_build_options to gen_libs_config.json
- Added GENERATE_DEBUG_SYMBOLS=YES to xcode_build_options for Debug build
- Divided static link lib outputdir, Debug and Release
- You can source code debug,
  - 'cocos gen-libs -m debug -p ios --dis-strip'
  - Add 'TO_YOUR_COCOS2DX_PATH/prebuilt/ios/$(CONFIGURATION)' to your project's Library Search Paths
  - Add '-l"cocos2d iOS" to your project's Other Linker Flags
