### PR TITLE
fix default shell environment detection error

### DIFF
--- a/bin/cocos
+++ b/bin/cocos
@@ -1,4 +1,7 @@
-#!/bin/bash -l
+#!/bin/bash
+shell=${SHELL}
+
+#!${shell} -l
 
 COCOS_CONSOLE_BIN_DIRECTORY=$(dirname "$0")
 COCOS_CONSOLE_BIN_DIRECTORY=$(cd "$COCOS_CONSOLE_BIN_DIRECTORY" && pwd -P)


### PR DESCRIPTION
Some users`s default shell are not bash , cocos util would not get correct os.env variable when using wrong default SHELL
