### PR TITLE
Flush logging message before launch subprocess.

### DIFF
--- a/bin/cocos.py
+++ b/bin/cocos.py
@@ -178,6 +178,7 @@ class CMDRunner(object):
         else:
             log_path = CCPlugin._log_path()
             command += ' >"%s" 2>&1' % log_path
+        sys.stdout.flush()
         ret = subprocess.call(command, shell=True, cwd=cwd)
         if ret != 0:
             message = MultiLanguage.get_string('COCOS_ERROR_RUNNING_CMD_RET_FMT', str(ret))


### PR DESCRIPTION
Logging print in terminal is printed correctly before subprocess.

But when `cocos` command it self is launched by nodejs/atom and outputs are read by pipe ([see atom build](https://github.com/noseglid/atom-build/blob/d832db279b49cbfb6975c01b61c321ddf7a71b48/lib/build.js#L417-L433))
About 2~3 lines of logging message before subprocess will not printed until subprocess returns.

So we needs to flush logging messages before launch subprocess.
