### PR TITLE
fault-tolerant. call encrypt if and only if used cocos package to import plugin

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "version":"v3-console-13",
-    "zip_file_size":"42887049",
+    "zip_file_size":"42887263",
     "repo_name":"console-binary",
     "repo_parent":"https://github.com/natural-law/"
 }

--- a/plugins/plugin_compile/build_android.py
+++ b/plugins/plugin_compile/build_android.py
@@ -500,7 +500,7 @@ class AndroidBuilder(object):
                 else:
                     path = os.path.realpath(os.path.dirname(__file__))
                 path = os.path.join(path, '../plugin_package/cocospackage')
-                cmd = '%s encrypt -p %s --runincocos --runinbuild --noupdate' % (path, self.app_android_root)
+                cmd = '%s encrypt -p %s --mode %s --runincocos --runinbuild --noupdate' % (path, self.app_android_root, build_mode)
                 self._run_cmd(cmd)
         except:
             pass

--- a/plugins/plugin_compile/build_android.py
+++ b/plugins/plugin_compile/build_android.py
@@ -493,14 +493,15 @@ class AndroidBuilder(object):
 
         ##cocospackage
         try:
-            path = ''
-            if getattr(sys, 'frozen', None):
-                path = os.path.realpath(os.path.dirname(sys.executable))
-            else:
-                path = os.path.realpath(os.path.dirname(__file__))
-            path = os.path.join(path, '../plugin_package/cocospackage')
-            cmd = '%s encrypt -p %s --runincocos --runinbuild --noupdate' % (path, self.app_android_root)
-            self._run_cmd(cmd)
+            if os.path.exists(os.path.join(self._project.get_project_dir(), '.cocos-package.json')):
+                path = ''
+                if getattr(sys, 'frozen', None):
+                    path = os.path.realpath(os.path.dirname(sys.executable))
+                else:
+                    path = os.path.realpath(os.path.dirname(__file__))
+                path = os.path.join(path, '../plugin_package/cocospackage')
+                cmd = '%s encrypt -p %s --runincocos --runinbuild --noupdate' % (path, self.app_android_root)
+                self._run_cmd(cmd)
         except:
             pass
         

--- a/plugins/plugin_compile/project_compile.py
+++ b/plugins/plugin_compile/project_compile.py
@@ -642,14 +642,15 @@ class CCPluginCompile(cocos.CCPlugin):
 
         #cocospackage
         try:
-            path = ''
-            if getattr(sys, 'frozen', None):
-                path = os.path.realpath(os.path.dirname(sys.executable))
-            else:
-                path = os.path.realpath(os.path.dirname(__file__))
-            path = os.path.join(path, '../plugin_package/cocospackage')
-            cmd = '%s encrypt -p %s --platform ios --runincocos --runinbuild --noupdate' % (path, self._project.get_project_dir())
-            self._run_cmd(cmd)
+            if os.path.exists(os.path.join(self._project.get_project_dir(), '.cocos-package.json')):
+                path = ''
+                if getattr(sys, 'frozen', None):
+                    path = os.path.realpath(os.path.dirname(sys.executable))
+                else:
+                    path = os.path.realpath(os.path.dirname(__file__))
+                path = os.path.join(path, '../plugin_package/cocospackage')
+                cmd = '%s encrypt -p %s --platform ios --runincocos --runinbuild --noupdate' % (path, self._project.get_project_dir())
+                self._run_cmd(cmd)
         except:
             pass
         

--- a/plugins/plugin_compile/project_compile.py
+++ b/plugins/plugin_compile/project_compile.py
@@ -649,7 +649,7 @@ class CCPluginCompile(cocos.CCPlugin):
                 else:
                     path = os.path.realpath(os.path.dirname(__file__))
                 path = os.path.join(path, '../plugin_package/cocospackage')
-                cmd = '%s encrypt -p %s --platform ios --runincocos --runinbuild --noupdate' % (path, self._project.get_project_dir())
+                cmd = '%s encrypt -p %s --mode %s --platform ios --runincocos --runinbuild --noupdate' % (path, self._project.get_project_dir(), self._mode)
                 self._run_cmd(cmd)
         except:
             pass


### PR DESCRIPTION
1.add mode param when call cocos package encrypt
2.fault-tolerant. call encrypt if and only if used cocos package to import plugin
