### PR TITLE
Fix AttributeError: 'CCPluginCompile' object has no attribute 'project_name'

### DIFF
--- a/plugins/plugin_compile/project_compile.py
+++ b/plugins/plugin_compile/project_compile.py
@@ -1341,10 +1341,13 @@ class CCPluginCompile(cocos.CCPlugin):
             self.project_name = cfg_obj.project_name
         else:
             f = open(os.path.join(cmakefile_dir, 'CMakeLists.txt'), 'r')
+            regexp_set_app_name = re.compile(r'\s*set\s*\(\s*APP_NAME', re.IGNORECASE)
             for line in f.readlines():
-                if "set(APP_NAME " in line:
-                    self.project_name = re.search('APP_NAME ([^\)]+)\)', line).group(1)
+                if regexp_set_app_name.search(line):
+                    self.project_name = re.search('APP_NAME ([^\)]+)\)', line, re.IGNORECASE).group(1)
                     break
+            if hasattr(self, 'project_name') == False:
+	            raise cocos.CCPluginError("Cauldn't find APP_NAME in CMakeLists.txt")
 
         if cfg_obj.build_dir is not None:
             build_dir = os.path.join(project_dir, cfg_obj.build_dir)


### PR DESCRIPTION
Fix for such bug:

In CMakeLists.txt script is searching for `"set(APP_NAME "` but for example CLion formats CMakeLists.txt and make it:

```
SET(APP_NAME  MyApp)
```

Error occurs:

```
Deploying mode: debug
Traceback (most recent call last):
  File "/home/dawid/Projects/ESportSolutions/Games/cocos2d-x/tools/cocos2d-console/bin/cocos.py", line 998, in <module>
    run_plugin(command, argv, plugins)
  File "/home/dawid/Projects/ESportSolutions/Games/cocos2d-x/tools/cocos2d-console/bin/cocos.py", line 913, in run_plugin
    dep_name, argv, plugins)
  File "/home/dawid/Projects/ESportSolutions/Games/cocos2d-x/tools/cocos2d-console/bin/cocos.py", line 916, in run_plugin
    plugin.run(argv, dependencies_objects)
  File "/home/dawid/Projects/ESportSolutions/Games/cocos2d-x/tools/cocos2d-console/plugins/plugin_deploy.py", line 205, in run
    self.deploy_linux(dependencies)
  File "/home/dawid/Projects/ESportSolutions/Games/cocos2d-x/tools/cocos2d-console/plugins/plugin_deploy.py", line 167, in deploy_linux
    self.project_name = compile_dep.project_name
AttributeError: 'CCPluginCompile' object has no attribute 'project_name'
```

Now it can find it and accepts forms like:

```
SET(APP_NAME MyApp)
set(APP_NAME MyApp)
      set(APP_NAME MyApp)
        SET     (    APP_NAME MyApp)
```

If it still can't find APP_NAME we get nice error message:

`Cauldn't find APP_NAME in CMakeLists.txt`
