### PR TITLE
Add openjdk support to web build

### DIFF
--- a/plugins/plugin_compile/build_web/__init__.py
+++ b/plugins/plugin_compile/build_web/__init__.py
@@ -19,7 +19,7 @@ def check_jdk_version():
 
     jdk_version = None
     for line in child.stderr:
-        if 'java version' in line:
+        if 'java version' in line or 'openjdk version' in line:
             if '1.6' in line:
                 jdk_version = JDK_1_6
             else:


### PR DESCRIPTION
For users with openjdk 1.8, "java -version" command output "openjdk version" instead of "java version". As cocos2d-x supports linux, I think maybe you are willing to support openjdk too! Thanks.
