### PR TITLE
Added a function to "properly" compare XCode version numbers

### DIFF
--- a/bin/cocos.py
+++ b/bin/cocos.py
@@ -717,6 +717,29 @@ def get_xcode_version():
 
     return version
 
+def version_minimum(a, b):
+    '''Compares two version numbers to see if a >= b
+
+    expects two dot separated version numbers
+    can be string, float or int
+    '''
+    if a == b or str(a).strip() == str(b).strip():
+        return True
+
+    a = [int(x) for x in str(a).split(".")]
+    b = [int(x) for x in str(b).split(".")]
+    for i in range(max(len(a), len(b))):
+        ai, bi = 0, 0
+        if len(a) > i:
+            ai = a[i]
+        if len(b) > i:
+            bi = b[i]
+        if ai > bi:
+            return True
+        if ai < bi:
+            return False
+
+    return True
 
 def copy_files_in_dir(src, dst):
 

--- a/plugins/plugin_compile/project_compile.py
+++ b/plugins/plugin_compile/project_compile.py
@@ -804,10 +804,12 @@ class CCPluginCompile(cocos.CCPlugin):
                 "CONFIGURATION_BUILD_DIR=\"%s\"" % (output_dir),
                 "%s" % "VALID_ARCHS=\"i386\"" if self.use_sdk == 'iphonesimulator' else ''
                 ])
- 
+
             # PackageApplication is removed since xcode 8.3, should use new method to generate .ipa
             # should generate .xcarchive first, then generate .ipa
-            use_new_ipa_method = float(cocos.get_xcode_version()) >= 8.3
+            xcode_version = cocos.get_xcode_version()
+
+            use_new_ipa_method = cocos.version_minimum(xcode_version, 8.3)
 
             if self._sign_id is not None:
                 if use_new_ipa_method:


### PR DESCRIPTION
I ran into a problem similar to #422 : 
```
$ cocos compile -p ios
Building mode: debug
Building...
invalid literal for float(): 8.3.3

Build failed: Take a look at the output above for details.
```

There are problems with trying to convert version numbers to ints or strings, for example:
```
3.10.1 == 3.1.0.1
```
(If you remove dots and convert to string/int as in #422 )

I made some simple logic to properly compare version numbers: (Does not support hex or alphanumeric)
```python3
def version_minimum(a, b):
    '''Compares two version numbers to see if a >= b                                                                                                          
                                                                                                                                                              
    expects two dot separated version numbers                                                                                                                 
    can be string, float or int                                                                                                                               
    '''
    if a == b or str(a).strip() == str(b).strip():
        return True

    a = [int(x) for x in str(a).split(".")]
    b = [int(x) for x in str(b).split(".")]
    for i in range(max(len(a), len(b))):
        ai, bi = 0, 0
        if len(a) > i:
            ai = a[i]
        if len(b) > i:
            bi = b[i]
        if ai > bi:
            return True
        if ai < bi:
            return False

    return True

assert version_minimum(1, 1.0)
assert version_minimum(1, "1.0.0")
assert version_minimum(2, 1)
assert version_minimum(2.0, 1.0)
assert version_minimum(2.3, 2.2)
assert version_minimum("8.3.3", 8.3)
assert version_minimum("3.10.1", "3.1.0.1")
assert not version_minimum(1, 2)
assert not version_minimum(8.2, 8.3)
assert not version_minimum("8.0.0.1", 8.1)
assert not version_minimum("3.1.0.1", "3.10.1")
print("Works fine")
```

Passes the above test:
```bash
$ python3 version_minimum.py 
Works fine
```