### PR TITLE
Add back gradle_support_ndk initialization

### DIFF
--- a/plugins/plugin_compile/project_compile.py
+++ b/plugins/plugin_compile/project_compile.py
@@ -478,6 +478,8 @@ class CCPluginCompile(cocos.CCPlugin):
         cocos.Logging.info(MultiLanguage.get_string('COMPILE_INFO_ANDROID_PROJPATH_FMT', (ide_name, project_android_dir)))
 
         # Check whether the gradle of the project is support ndk or not
+        gradle_support_ndk = False
+
         # Get the engine version of the project
         engine_version_num = self.get_engine_version_num()
         if engine_version_num is None:


### PR DESCRIPTION
Probably `gradle_support_ndk` is removed accidentally in https://github.com/cocos2d/cocos2d-console/commit/0e50ef19725d586c8688f9509d056137a50ed7b5