### PR TITLE
disable cmd "plugin", "gen-libs", for not supported

### DIFF
--- a/bin/cocos2d.ini
+++ b/bin/cocos2d.ini
@@ -23,10 +23,10 @@ plugin_run.CCPluginRun
 plugin_deploy.CCPluginDeploy
 plugin_jscompile.CCPluginJSCompile
 plugin_luacompile.CCPluginLuaCompile
-plugin_generate.LibsCompiler
+# plugin_generate.LibsCompiler
 plugin_generate.SimulatorCompiler
 #plugin_generate.TemplateGenerator
-plugin_package.CCPluginPackage
+; plugin_package.CCPluginPackage
 #plugin_gui.CCPluginGUI
 #plugin_version.CCPluginVersion
 #plugin_install.CCPluginInstall


### PR DESCRIPTION
disbale cmd, since we didn't maintain it.
```
gen-libs         Generate prebuilt libs of engine. The libs will be placed in 'prebuilt' folder of the engine root path.
package          Manage package for cocos.
```

if we keep it here, developer will try to execute, and ask why `gen-libs` failed again.