### PR TITLE
Fix running applications on linux

### DIFF
--- a/plugins/plugin_compile/project_compile.py
+++ b/plugins/plugin_compile/project_compile.py
@@ -1425,7 +1425,7 @@ class CCPluginCompile(cocos.CCPlugin):
         if cfg_obj.build_result_dir is not None:
             result_dir = os.path.join(build_dir, 'bin', cfg_obj.build_result_dir, build_mode, self.project_name)
         else:
-            result_dir = os.path.join(build_dir, 'bin', build_mode, self.project_name)
+            result_dir = os.path.join(build_dir, 'bin', self.project_name)
         cocos.copy_files_in_dir(result_dir, output_dir)
 
         self.run_root = output_dir


### PR DESCRIPTION
Application are compiled in the directory linux-build/bin/<%app name%>, not a directory linux-build/bin/<%Debug/Release%>/<%app name%>.
Without this hotfix, You receive error
OSError: [Errno 2] No such file or directory: '/path/to/project/linux-build/bin/Release/<%app name%>'