### PR TITLE
add openjdk to web-build

### DIFF
--- a/plugins/plugin_compile/build_web/__init__.py
+++ b/plugins/plugin_compile/build_web/__init__.py
@@ -19,7 +19,7 @@ def check_jdk_version():
 
     jdk_version = None
     for line in child.stderr:
-        if 'java version' in line:
+        if 'java version' or 'openjdk version' in line:
             if '1.6' in line:
                 jdk_version = JDK_1_6
             else:


### PR DESCRIPTION
 Java SE 8 public updates will no longer be available for a specific use without a commercial license.
Here is link: https://java.com/en/download/release_notice.jsp

To build for web, we will need to use open jdk